### PR TITLE
Mint image for Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+workspace
+*.md
+*.yml

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,0 +1,16 @@
+FROM crystallang/crystal:0.36.1-alpine AS build
+
+RUN mkdir -p /opt/build
+WORKDIR /opt/build
+RUN git clone https://github.com/mint-lang/mint.git .
+RUN shards install
+RUN crystal build src/mint.cr -o mint --static --release --no-debug
+
+FROM alpine
+RUN mkdir -p /opt/mint
+COPY --from=build /opt/build/mint /bin/mint
+COPY ./bin/entrypoint /bin/entrypoint
+
+WORKDIR /opt/mint
+ENTRYPOINT [ "/bin/entrypoint" ]
+CMD [ "start" ]

--- a/bin/build-image
+++ b/bin/build-image
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -eu
+
+# Begin in project root
+cd "$(git rev-parse --show-toplevel)"
+docker build -f Dockerfile.alpine -t mint .

--- a/bin/entrypoint
+++ b/bin/entrypoint
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -eu
+
+if [ -t 1 -a $# -eq 0 ]; then exec sh
+else exec mint $@
+fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,13 @@
-version: '2'
+version: "2.4"
 services:
   mint:
-    image: alpine
-    tty: true
+    image: mint
+    build:
+      context: ./
+      dockerfile: Dockerfile.alpine
     volumes:
-      - ./bin:/bin
-      - ./workspace:/workspace
-    working_dir: /workspace
-    command: mint start --host 0.0.0.0
+      - ./workspace:/opt/mint
+    working_dir: /opt/mint
+    command: start --host 0.0.0.0
     ports:
       - 3000:3000
-    environment:
-        - PATH=/bin:$PATH


### PR DESCRIPTION
Hi Mint team! I'd like a Docker image containing a `mint` binary built from source that I can then use to compile Mint programs.

### Current solution / workaround
This repo contains a Mint binary that somebody built from source and a `docker-compose.yml` that mounts it into Alpine. My issue with that approach is it's not super convenient for downstream automation, and you have to trust the mint binary in the repo (or build it yourself.)

### Proposed solution
I can create a Dockerfile with two stages, the first of which builds Mint from source and the second of which copies that into an Alpine environment.

What do you think?